### PR TITLE
Fix to correctly point the back-end server to the front-end code

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -16,9 +16,9 @@ app.use((req, res, next) => {
 app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.json());
 app.use('/api', api);
-app.use(express.static(path.resolve(__dirname, 'test_public')));
+app.use(express.static(path.resolve(__dirname, '../client/build')));
 app.get('*', (req, res) => {
     console.log('index accessed');
-    res.sendFile(path.join(__dirname, 'test_public/test_index.html'));
+    res.sendFile(path.join(__dirname, '../client/build/index.html'));
 });
 


### PR DESCRIPTION
Path fix for server.js. This is needed so we can properly serve the static front-end files on the server. Right now we have been copying files over manually but with deployment in place those changes will be wiped every time there is a pr, so we gotta get this fixed. This should also be merged into dev.