### PR TITLE
Fix/teampics centered

### DIFF
--- a/src/components/TeamPics/teampics.scss
+++ b/src/components/TeamPics/teampics.scss
@@ -1,16 +1,15 @@
 /* HEXAGON DESIGN code taken from and edited: https://www.codesmite.com/article/how-to-create-pure-css-hexagonal-grids */
 
 .TEAMPICTURE {
-  
     #grid {
         position: relative;
-        width: 70%; /* Scales original sizes */
+        width: 75%; /* Scales original sizes */
         margin: 0 auto;
         padding: 0 0 5% 0; /* Padding under Grid component (under last row of hexagons) */
     }
 
     .clear:after {
-        content: '';
+        content: "";
         display: block;
         clear: both;
     }
@@ -107,5 +106,9 @@
         @media only screen and (min-width: 1200px) {
             font-size: 40px;
         }
+    }
+
+    .CenterHexagons {
+        margin-left: 5.5%;
     }
 }

--- a/src/components/TeamPics/teampics.tsx
+++ b/src/components/TeamPics/teampics.tsx
@@ -32,7 +32,13 @@ function teampics(team: Array<{ url: string; src: any; alt: string }>): JSX.Elem
         );
     });
 
-    return <ul id="grid" className="clear">{teamArray}</ul>;
+    return (
+        <ul id="grid" className="clear">
+            <div className="CenterHexagons">
+                {teamArray}
+            </div>
+        </ul>
+    );
 }
 
 const TeamPics: FC = (): JSX.Element => {


### PR DESCRIPTION
## Proposed changes

Using Inspect Element, I found that the hexagons inside <ul id:"grid" className="clear">, were not centered, so I created a div inside it that encompasses all hexagons, and margin-left shifted the new div a tiny bit. This centered all the hexagons, and the entire component is still responsive. Since this new change scaled down the hexagon sizes, I had to scale them up by 5% width (.sccs line 6).

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/UCMercedACM/Chapter-Website/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

For some reason, margin: auto did not center all the hexagons when put in the new div's .scss. Maybe the correct way to center them is to center each hexagon in the div, however this would mess up the honeycomb styling of the entire component, and we would need to change a lot of code (such as scaling).
