### PR TITLE
Fix/teampics hexagon sizing

### DIFF
--- a/src/components/TeamPics/teampics.scss
+++ b/src/components/TeamPics/teampics.scss
@@ -77,6 +77,80 @@
         margin-left: 0.4%;
     }
 
+    /* Small devices (phones, portrait tablets, and large phones, 850px and lower) */
+    @media only screen and (max-width: 850px) {
+        #grid {
+            position: relative;
+            width: 100%; /* Scales original sizes */
+            margin: 0 auto;
+            padding: 0 0 5% 0; /* Padding under Grid component (under last row of hexagons) */
+        }
+
+        /* Parallelogram */
+        #grid li {
+            list-style-type: none;
+            position: relative;
+            float: left;
+            width: 14.85714285714286%; /* Directly related to original hexagon size */
+            padding: 0% 0% 17% 0%; /* Directly related to original hexagon size */
+            -o-transform: rotate(-60deg) skewY(30deg);
+            -moz-transform: rotate(-60deg) skewY(30deg);
+            -webkit-transform: rotate(-60deg) skewY(30deg);
+            -ms-transform: rotate(-60deg) skewY(30deg);
+            transform: rotate(-60deg) skewY(30deg);
+            background: #fd005f;
+            overflow: hidden;
+            visibility: hidden;
+        }
+
+        #grid li:nth-child(1) { 
+            margin-left: 25%;
+        } 
+
+        /* Translates each child in the second row (starting child 5) to the right a little bit, and moves them down. */
+        #grid li:nth-child(5),
+        #grid li:nth-child(6),
+        #grid li:nth-child(7) {
+            margin-top: -3.2%;
+            margin-bottom: 0%;
+            -o-transform: translateX(50%) rotate(-60deg) skewY(30deg);
+            -moz-transform: translateX(50%) rotate(-60deg) skewY(30deg);
+            -webkit-transform: translateX(50%) rotate(-60deg) skewY(30deg);
+            -ms-transform: translateX(50%) rotate(-60deg) skewY(30deg);
+            transform: translateX(50%) rotate(-60deg) skewY(30deg);
+        }
+        /* Translates each child in the second row (starting child 8) to the right a little bit, and moves them down. */
+        #grid li:nth-child(8),
+        #grid li:nth-child(9),
+        #grid li:nth-child(10),
+        #grid li:nth-child(11) {
+            margin-top: -3.2%;
+            margin-bottom: 0%;
+            -o-transform: translateX(50%) rotate(-60deg) skewY(30deg);
+            -moz-transform: translateX(50%) rotate(-60deg) skewY(30deg);
+            -webkit-transform: translateX(50%) rotate(-60deg) skewY(30deg);
+            -ms-transform: translateX(50%) rotate(-60deg) skewY(30deg);
+            transform: translateX(50%) rotate(-60deg) skewY(30deg);
+        }
+
+        /* Aligns second and third rows into honeycomb style */
+        #grid li:nth-child(5) { 
+            margin-left: 25.5%;
+        } 
+        #grid li:nth-child(8) { 
+            margin-left: 17.5%;
+        } 
+
+        /* Child 7 was shifted to the right a little bit for some reason, so this fixes it. */
+        #grid li:nth-child(7) { 
+            margin-left: -0.05%;
+        } 
+
+        .CenterHexagons {
+            margin-right: 15.8%;
+        }
+    }
+
     .Header {
         padding: 3% 0% 2% 5%;
 


### PR DESCRIPTION
## Proposed changes

The size of the hexagon pictures were too small for width 850px and below, so I made a media query (max-width: 850px) that changed the amount of hexagons per row and made them bigger sized. Again, the centering of the hexagons were confusing, so I had to finish up with changing the div with className="CenterHexagons" 's margin-right.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/UCMercedACM/Chapter-Website/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The centering of the hexagons is very confusing, so so far I've been hard-coding rows to center them (margin-left and margin-right). This component is still responsive.

## How it looked
![hexagonsizingbefore](https://user-images.githubusercontent.com/43284404/87217189-84464900-c2fb-11ea-8eeb-7b4896551de7.png)

## How it looks Now
![hexagonsizing](https://user-images.githubusercontent.com/43284404/87217134-11d56900-c2fb-11ea-8f88-f62e7f517053.png)
 