### PR TITLE
Fix/mlh logo opacity

### DIFF
--- a/src/components/About Us/about.scss
+++ b/src/components/About Us/about.scss
@@ -9,7 +9,12 @@ $titles: black;
         border-radius: 25px;
         margin: 0 auto;
 
-         /* Small devices (iphones, 350px and up) */
+        /* Smallest devices (iphones, 350px and lower) */
+        @media only screen and (max-width: 350px) {
+            width: 30%;
+        }
+
+        /* Small devices (iphones, 350px and up) */
          @media only screen and (min-width: 350px) {
             width: 30%;
         }
@@ -79,6 +84,12 @@ $titles: black;
 
             p {
                 text-align: left;
+
+                @media (max-width: 350px) {
+                    width: 80%;
+                    margin-left: 10%;
+                    font-size: 105%;
+                }
 
                 @media (min-width: 350px) {
                     width: 80%;

--- a/src/components/NavBar/navbar.scss
+++ b/src/components/NavBar/navbar.scss
@@ -1,7 +1,8 @@
 .MLH {
-  position: fixed;
+  position: absolute;
   top: 1%;
   left: 1%;
+  opacity: 1;
 
   @media (min-width: 100px) {
       width: 60px;

--- a/src/components/NavBar/navbar.tsx
+++ b/src/components/NavBar/navbar.tsx
@@ -70,10 +70,10 @@ const Styles = {
 
         @media only screen and (max-width: 40em) {
             height: ${(): string => {
-                const { pathname } = useLocation();
-                return pathname !== '/' ? '13vw' : 'auto';
-            }};
+            const { pathname } = useLocation();
+            return pathname !== '/' ? '13vw' : 'auto';
         }
+        };
     `,
 };
 
@@ -86,12 +86,12 @@ const Menu = {
         justify-content: space-between;
         align-items: center;
 
-        // 40em == 640px
+/*         // 40em == 640px
         @media only screen and (max-width: 40em) {
             position: fixed;
             width: 100vw;
             top: 0;
-        }
+        } */
     `,
     Logo: styled.h1`
         padding: 0.5rem 1rem;

--- a/src/components/Past-Winners/past-winners.scss
+++ b/src/components/Past-Winners/past-winners.scss
@@ -37,8 +37,13 @@ $titles: black;
         border-radius: 25px;
         margin: 0 auto;
 
-         /* Small devices (iphones, 350px and up) */
-         @media only screen and (min-width: 350px) {
+        /* Smallest devices (iphones, 350px and lower) */
+        @media only screen and (max-width: 350px) {
+            width: 30%;
+        }
+
+        /* Small devices (iphones, 350px and up) */
+        @media only screen and (min-width: 350px) {
             width: 30%;
         }
 

--- a/src/components/TeamPics/teampics.scss
+++ b/src/components/TeamPics/teampics.scss
@@ -162,11 +162,12 @@
 
         /* Media Queries taken from and edited: https://www.w3schools.com/css/css_rwd_mediaqueries.asp */
 
-        /* Small devices (phones, portrait tablets, and large phones, 600px and up) */
-          /* Small devices (iphones, 350px and up) */
-          @media only screen and (min-width: 350px) {
+        /* Small devices (iphones, 350px and up) */
+        @media only screen and (min-width: 350px) {
             font-size: 25px;
         }
+
+        /* Small devices (phones, portrait tablets, and large phones, 600px and up) */
         @media only screen and (min-width: 600px) {
             font-size: 25px;
         }
@@ -198,8 +199,13 @@
         border-radius: 25px;
         margin: 0 auto;
 
-         /* Small devices (iphones, 350px and up) */
-         @media only screen and (min-width: 350px) {
+        /* Smallest devices (iphones, 350px and lower) */
+        @media only screen and (max-width: 350px) {
+            width: 30%;
+        }
+
+        /* Small devices (iphones, 350px and up) */
+        @media only screen and (min-width: 350px) {
             width: 30%;
         }
 

--- a/src/components/TeamPics/teampics.tsx
+++ b/src/components/TeamPics/teampics.tsx
@@ -69,9 +69,8 @@ const TeamPics: FC = (): JSX.Element => {
 
         team.forEach((member: TeamPicsState, index: number) => {
             const name: string = member.src.includes('/')
-                ? member.src.split('/')[4].split('.')[0]
+                ? member.src.split('/')[3].split('.')[0]
                 : member.src.split('.')[0];
-
             teamArray.push(
                 <li key={index}>
                     <div className="hexagon">


### PR DESCRIPTION
# Changes Description

On Mobile View, the MLH Banner and Hamburger Menu Button were obscuring wording on different pages of the Hub. So I took out the media query that was responsible for allowing both of them to scroll down with the user. I also added media queries for the three breakpoints on the Home page, max-width instead of min-width.

## Types of changes

What types of changes does your code introduce to HackMerced Hub?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/HackMerced/HackMerced/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## What Still Needs to be Fixed
![image](https://user-images.githubusercontent.com/43284404/89743193-7cdaa280-da55-11ea-826e-8491f5f06e0e.png)
![image](https://user-images.githubusercontent.com/43284404/89743195-882dce00-da55-11ea-848a-ef14d21ababe.png)
Pictures are showing over the Hamburger Menu.
![image](https://user-images.githubusercontent.com/43284404/89743200-9a0f7100-da55-11ea-9faa-8de92ef1e163.png)
The MLH Banner covers the wording in Sponsors and Contact Us pages under certain screen width dimensions.

