### PR TITLE
Frontend Fixes for Designathon Page, FAQ Component

### DIFF
--- a/src/components/Accordian/Accordian.scss
+++ b/src/components/Accordian/Accordian.scss
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Quicksand:300, 400, 700');
+@import url("https://fonts.googleapis.com/css?family=Quicksand:300, 400, 700");
 
 .accordion {
     background-color: #0d0721;
@@ -6,18 +6,16 @@
     flex-wrap: wrap;
     justify-content: center;
 
-   
-
     &__item {
-        flex: 1 1 150px; /*  Stretching: */
-        flex: 0 1 150px; /*  No stretching: */
-        margin: 0 20px 30px 20px;
+        //flex: 1 1 150px; /*  Stretching: */
+        //flex: 0 1 150px; /*  No stretching: */
+        margin: 0 20px 30px 20px; //margin around each accordion_item
 
         &__title {
             height: 55px;
             width: 500px;
-            background-color: #2D2058;
-            color: #EEEBF5;
+            background-color: #2d2058;
+            color: #eeebf5;
             text-transform: uppercase;
             letter-spacing: 1px;
             text-align: left;
@@ -31,22 +29,16 @@
             transition: all 0.2s ease-in;
 
             @media only screen and (max-width: 500px) {
-                width: 40vh;
-                height: 10vh;
-                margin: 0% 0% 0% 15%;
-             }
-
-             @media only screen and (max-width: 360px) {
-                width: 50vh;
-                height: 15vh;
-                margin: 0% 0% 0% 18%;
-             }
-            //  @media only screen and (max-width: 450px) {
-            //     width: 50vh;
-            //     height: 12vh;
-            //     margin: 0% 0% 0% 13%;
-            //  }
-          
+                //media queries for accordion_item_titles
+                width: 35vh;
+                height: 105px; //had to increase the height for iphone5/SE and higher
+                margin-left: 50%; //move to center
+            }
+            @media only screen and (max-width: 400px) {
+                width: 35vh;
+                height: 105px; //had to increase the height for iphone5/SE and higher
+                margin-left: 40%; //move left of center
+            }
 
             &:hover {
                 cursor: pointer;
@@ -70,8 +62,6 @@
                 .fa-rotate-180 {
                     color: rgba(255, 255, 255, 1);
                 }
-
-               
             }
 
             &__title-text {
@@ -101,7 +91,7 @@
                 transition: all 0.2s ease-in;
 
                 a {
-                  text-decoration: underline;
+                    text-decoration: underline;
                 }
             }
 
@@ -109,11 +99,18 @@
                 visibility: visible;
                 opacity: 1;
                 transition: all 0.8s ease-in;
+
                 @media only screen and (max-width: 500px) {
-                    width: 50vh;
-                    margin: 0% 0% 0% 12%;
-                   
-                 }
+                    //media queries for accordion_item_contents
+                    width: 35vh;
+                    height: 100%;
+                    margin-left: 50%;
+                }
+                @media only screen and (max-width: 400px) {
+                    width: 35vh;
+                    height: 100%;
+                    margin-left: 40%;
+                }
             }
         }
 
@@ -122,8 +119,13 @@
             height: 200px;
             background-color: rgba(0, 0, 0, 0.1);
             transition: all 350ms cubic-bezier(0.08, 1.09, 0.32, 1.275);
-
-          
         }
+    }
+
+    @media only screen and (max-width: 500px) {
+        // when accordion_item_titles and accordion_item_contents flex on top of each other,
+        // we need to shift the entire accordion container to the left so that accordion_items and contents don't budge off the screen
+        // and thus allow the user to swipe left and right on the Designathon page.
+        margin-right: 50%;
     }
 }


### PR DESCRIPTION
When the browser width is lower than 500px, the FAQ titles and contents flex under each other. However because of this the width of the title and content containers would go off the screen, and thus allow the user to swipe left and right on their browser.
Before these fixes, you would be able to go off-screen starting at width 500px and lower, and see a gray box for the contents off-screen. With these fixes, you would be able to go off-screen under width 333px. I had to adjust some height and width too in order to make sure the fixes worked on iPhone5/SE.

# Proposed changes

I viewed the designathon page on my iphone SE 2020, and was able to swipe off screen. I thought the issue was because of the DesignMerced Online image going off-screen, but found that the cause is from accordian_items and accordian_item_contents in the FAQ component (Accordian.scss). These containers' widths would flex out of the browser screen when they flexed under and over each other under resolution width 500px.

## Types of changes

What types of changes does your code introduce to HackMerced Hub?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/HackMerced/HackMerced/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Responsiveness

Check off the different **browsers** and **devices** you have tested on.

### Browsers

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

I don't know why it goes off-screen on Firefox. Works fine on Chrome until under width 333px. Tested mainly on Chrome.
Viewed current designathon page on iPhone SE 2020 on Safari.

### Devices

- [x] Windows
- [ ] MacOSX
- [ ] Linux
- [x] IPhone
- [ ] Android
- [ ] Tablet

Can't test my fixes on my iphone if the code is not deployed (right..?).

## Screenshots

//
CHROME after fixes
//
![image](https://user-images.githubusercontent.com/43284404/97372379-c080c380-1870-11eb-9f15-0f57712ffe08.png)
//
![image](https://user-images.githubusercontent.com/43284404/97372563-28cfa500-1871-11eb-91ef-6178d56dc433.png)
//
![image](https://user-images.githubusercontent.com/43284404/97372529-135a7b00-1871-11eb-8ea8-a919a234a322.png)
Able to scroll off-screen under width 333px.

//
iPHONE SE 2020 SAFARI before fixes
//
![123062969_460896634890410_7307922788328745565_n](https://user-images.githubusercontent.com/43284404/97372807-b4e1cc80-1871-11eb-9e77-8491c5ce79a1.jpg)
//
![122981443_788644961706892_541691842098789388_n](https://user-images.githubusercontent.com/43284404/97372815-b7442680-1871-11eb-9290-f22d3f6a0fdb.jpg)
//
![123048143_790422044862579_9108447851273312056_n](https://user-images.githubusercontent.com/43284404/97372816-b90dea00-1871-11eb-908e-7aadbf2cfa23.jpg)
//
![123003272_2730210453914122_167867503909355770_n](https://user-images.githubusercontent.com/43284404/97372822-bc08da80-1871-11eb-8230-6996e6d747e0.jpg)


## Further comments

I found that you can scroll off-screen between widths 911 and 993. I don't know how to fix this issue. I'm guessing it has to do with the mobile-view navbar.
