### PR TITLE
Deleted opacity for break-lines on home page

### DIFF
--- a/src/pages/Home/styles.scss
+++ b/src/pages/Home/styles.scss
@@ -339,7 +339,6 @@
     */
     &__break-line {
         border: 0.5rem solid var(--orange);
-        opacity: 0.5;
         border-width: 0.5rem;
         border-radius: 10px;
         margin: 0 auto 1rem auto;


### PR DESCRIPTION
Didn't need the opacity to be changed. The break-lines will be visible without changing the opacity for some reason...

## Types of changes

What types of changes does your code introduce to HackMerced Hub?
_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/HackMerced/HackMerced/blob/master/CONTRIBUTING.md) doc
-   [x] Lint and unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Responsiveness

Check off the different **browsers** and **devices** you have tested on. Note: testing includes Horizontal and Vertical alignments

### Browsers

-   [x] Chrome
-   [ ] Firefox
-   [ ] Edge
-   [ ] Safari
-   [ ] Brave
-   [ ] Opera

### Devices

#### Phones

-   [ ] Moto G4
-   [ ] Galaxy S5
-   [ ] Pixel 2
-   [ ] Pixel 2 XL
-   [ ] iPhone 5/SE
-   [ ] iPhone 6/7/8
-   [ ] iPhone 6/7/8 Plus
-   [ ] iPhone X

#### Tablets

-   [ ] iPad
-   [ ] iPad Pro

#### Desktops

-   [x] Windows 10
-   [ ] MacOSX
-   [ ] Ubuntu

## Screenshots

![image](https://user-images.githubusercontent.com/43284404/113090753-4fd32f80-919f-11eb-94b9-76abfed9e426.png)

