### PR TITLE
Changed Home Heading height w/ heading subtext & button margin

### DIFF
--- a/src/pages/Home/styles.scss
+++ b/src/pages/Home/styles.scss
@@ -8,17 +8,22 @@
     */
     &__heading {
         background-image: var(--gradient);
-        height: 810px;
+        height: 750px;
         background-repeat: no-repeat;
         background-size: cover;
         overflow: hidden;
 
-        @media (max-width: 700px) {
+        @media (max-width: 650px) {  //Changes the height of the heading component
+            height: 700px;
+        }
+        @media (max-width: 550px) {
+            height: 650px;
+        }
+        @media (max-width: 450px) {
             height: 600px;
         }
-
-        @media (max-width: 450px) {
-            height: 400px;
+        @media (max-width: 380px) {
+            height: 540px;
         }
 
         // Scrolling clouds in the background of the heading
@@ -172,7 +177,7 @@
             &__sub-text {
                 font-size: 15px;
                 text-align: center;
-                margin: 1% auto auto 40%;
+                margin: 3% auto auto 40%;
                 font-weight: medium;
             }
 
@@ -197,14 +202,22 @@
 
                 &__text,
                 &__sub-text {
-                    margin: 3% 0 !important;
+                    margin: 3% 0 0 0;
+                }
+
+                &__text {
+                    margin-top: 8%;
+                }
+
+                &__sub-text {
+                    margin-top: 50px;
                 }
             }
 
             .subscribe-button {
                 position: relative;
                 text-transform: uppercase;
-                margin: 2% auto 0% 53%;
+                margin: 2% 15% 0% 52.4%;
                 font-size: 16px;
                 color: var(--text-color);
                 border-radius: 20px;
@@ -215,21 +228,16 @@
                 background-color: var(--background);
                 cursor: pointer;
 
-                /* Small devices (landscape tablets, 300px and up) */
+                /* Small devices (200px and up) */
                 @media only screen and (min-width: 200px) and (max-width: 775px) {
                     width: 65%;
                     padding: 4%;
-                    margin: 0;
+                    margin: 40px 0 0 0;
                     text-align: center;
                 }
 
-                /* Extra large devices (large laptops and desktops, 1200px and up) */
-                @media only screen and (min-width: 1200px) {
-                    width: 35%;
-                }
-
-                /* Extra large devices (large laptops and desktops, 1200px and up) */
-                @media only screen and (min-width: 1500px) {
+                /* Medium-large devices (laptops and desktops, 775px and up) */
+                @media only screen and (min-width: 775px) {
                     width: 35%;
                 }
 
@@ -274,7 +282,7 @@
 
         &__tower {
             display: block;
-            height: 900px;
+            height: 830px;
             width: 550px;
             margin: -25% 0% 0% 5%;
 
@@ -283,6 +291,9 @@
                 height: 850px;
                 width: 500px;
                 margin-top: -30%;
+            }
+            @media (max-width: 775px) {
+                display: none;
             }
         }
     }

--- a/src/pages/Home/styles.scss
+++ b/src/pages/Home/styles.scss
@@ -8,7 +8,7 @@
     */
     &__heading {
         background-image: var(--gradient);
-        height: 750px;
+        height: calc(100vh - 70px);
         background-repeat: no-repeat;
         background-size: cover;
         overflow: hidden;


### PR DESCRIPTION
# Proposed changes
The Home Heading's img, text, subtext, and subscribe button were too squished together. I had to change the height of the Home Heading component and add css to that, and fix the css margins between the subtext and subscribe button. By doing this we fill most of the empty space in our Heading component; especially when at lower resolutions.

## Types of changes

What types of changes does your code introduce to HackMerced Hub?
_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/HackMerced/HackMerced/blob/master/CONTRIBUTING.md) doc
-   [x] Lint and unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Responsiveness

Check off the different **browsers** and **devices** you have tested on. Note: testing includes Horizontal and Vertical alignments

### Browsers

-   [x] Chrome
-   [ ] Firefox
-   [ ] Edge
-   [ ] Safari
-   [ ] Brave
-   [ ] Opera

### Devices

#### Phones

-   [ ] Moto G4
-   [ ] Galaxy S5
-   [ ] Pixel 2
-   [ ] Pixel 2 XL
-   [x] iPhone 5/SE
-   [ ] iPhone 6/7/8
-   [ ] iPhone 6/7/8 Plus
-   [ ] iPhone X

#### Tablets

-   [ ] iPad
-   [ ] iPad Pro

#### Desktops

-   [x] Windows 10
-   [ ] MacOSX
-   [ ] Ubuntu

## Screenshots

I have to scroll down twice to exit the Home Heading component:
![image](https://user-images.githubusercontent.com/43284404/116025232-dc3d0a80-a604-11eb-8ae4-9ecb04b4c50f.png)
iPhone SE 2nd gen: I shouldn't be seeing the About Us text. The component height should be the full view height of my phone.
![178631436_362072985236530_517333739844884175_n](https://user-images.githubusercontent.com/43284404/116025252-e52ddc00-a604-11eb-838e-b56db91063ed.jpg)
Current website on desktop:
![image](https://user-images.githubusercontent.com/43284404/116025349-1e664c00-a605-11eb-9d1b-4e0c7e5e08bd.png)
After changes on desktop:
![image](https://user-images.githubusercontent.com/43284404/116025373-2d4cfe80-a605-11eb-8d41-21ebd4de354e.png)
Current website on desktop:
![image](https://user-images.githubusercontent.com/43284404/116025391-376efd00-a605-11eb-8e14-cf13dd04df09.png)
After changes on desktop: (tower css was changed in a previously merged PR)
![image](https://user-images.githubusercontent.com/43284404/116025414-4b1a6380-a605-11eb-98ad-8d3530270f91.png)



## Further comments

When I boot up the hackmerced website on my desktop, the Heading component height seems to be too tall (should be the full view height of the user's browser). And when I boot up the website on my phone, iPhone SE 2020, I can see the About Us text right underneath the Heading component. So I wanted to fix the component's height while addressing the margin problem.
