### PR TITLE
Fixed Home Heading height for higher than 650px width, up to 2000px

### DIFF
--- a/src/pages/Home/styles.scss
+++ b/src/pages/Home/styles.scss
@@ -13,10 +13,7 @@
         background-size: cover;
         overflow: hidden;
 
-        @media (min-width: 650px) {  //Changes the height of the heading component
-            height: 700px;
-        }
-        @media (max-width: 650px) {
+        @media (max-width: 650px) {  //Changes the height of the heading component
             height: 700px;
         }
         @media (max-width: 550px) {
@@ -288,6 +285,10 @@
             height: 830px;
             width: 550px;
             margin: -25% 0% 0% 5%;
+
+            @media (min-height: 800px) {  //Changes the height of the tower
+                height: calc(100vh + 30px);
+            }
 
             /* Medium devices (landscape tablets, 950px and under) */
             @media (max-width: 950px) {

--- a/src/pages/Home/styles.scss
+++ b/src/pages/Home/styles.scss
@@ -13,7 +13,10 @@
         background-size: cover;
         overflow: hidden;
 
-        @media (max-width: 650px) {  //Changes the height of the heading component
+        @media (min-width: 650px) {  //Changes the height of the heading component
+            height: 700px;
+        }
+        @media (max-width: 650px) {
             height: 700px;
         }
         @media (max-width: 550px) {


### PR DESCRIPTION
# Proposed changes

Added a min-width media query so resolution widths above 650px lock the home heading component's height to 700px. This is responsive until hitting 2000px width, where the tower's tip starts going up into the navbar and revealing the tower's bottom.

## Types of changes

What types of changes does your code introduce to HackMerced Hub?
_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/HackMerced/HackMerced/blob/master/CONTRIBUTING.md) doc
-   [x] Lint and unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Responsiveness

Check off the different **browsers** and **devices** you have tested on. Note: testing includes Horizontal and Vertical alignments

### Browsers

-   [x] Chrome
-   [x] Firefox
-   [x] Edge
-   [ ] Safari
-   [ ] Brave
-   [ ] Opera

### Devices

#### Phones

-   [x] Moto G4
-   [x] Galaxy S5
-   [x] Pixel 2
-   [x] Pixel 2 XL
-   [x] iPhone 5/SE
-   [x] iPhone 6/7/8
-   [x] iPhone 6/7/8 Plus
-   [x] iPhone X

#### Tablets

-   [ ] iPad
-   [ ] iPad Pro

#### Desktops

-   [x] Windows 10
-   [ ] MacOSX
-   [ ] Ubuntu

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/43284404/116746978-21b95900-a9b2-11eb-8ad9-b6bafc43db87.png)
After:
![image](https://user-images.githubusercontent.com/43284404/116747010-2978fd80-a9b2-11eb-97d8-5032ba3b4783.png)
After revision (changing tower height instead of locking home heading component height to 700px):

![image](https://user-images.githubusercontent.com/43284404/116749768-47486180-a9b6-11eb-9631-ec6090c3d9b5.png)
