### PR TITLE
Removed Potential for Users to see Floating HackMerced Tower

### DIFF
--- a/src/pages/Home/styles.scss
+++ b/src/pages/Home/styles.scss
@@ -322,13 +322,7 @@
             @media (min-height: 800px) {
                 height: calc(100vh + 30px);
             }
-
-            /* Medium devices (landscape tablets, 950px and under) */
-            @media (max-width: 950px) {
-                height: 850px;
-                width: 500px;
-                margin-top: -30%;
-            }
+            
             @media (max-width: 775px) {
                 display: none;
             }


### PR DESCRIPTION
# Proposed changes

Before, if the user's resolution is below 951px width and height over 950px, they will be able to see a floating HackMerced Tower. Removing this block of code sticks the tower's bottom height to the bottom of the section.

## Types of changes

What types of changes does your code introduce to HackMerced Hub?
_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/HackMerced/HackMerced/blob/master/CONTRIBUTING.md) doc
-   [x] Lint and unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Responsiveness

Check off the different **browsers** and **devices** you have tested on. Note: testing includes Horizontal and Vertical alignments

### Browsers

-   [x] Chrome
-   [ ] Firefox
-   [x] Edge
-   [ ] Safari
-   [ ] Brave
-   [ ] Opera

### Devices

#### Phones

-   [x] Moto G4
-   [x] Galaxy S5
-   [x] Pixel 2
-   [x] Pixel 2 XL
-   [x] iPhone 5/SE
-   [x] iPhone 6/7/8
-   [x] iPhone 6/7/8 Plus
-   [x] iPhone X

#### Tablets

-   [x] iPad
-   [x] iPad Pro

#### Desktops

-   [x] Windows 10
-   [ ] MacOSX
-   [ ] Ubuntu

## Screenshots

After Changes (Chrome):
![image](https://user-images.githubusercontent.com/43284404/121760547-36742b00-cae0-11eb-9f31-5290f944cfa5.png)

Before Changes (Chrome):
![image](https://user-images.githubusercontent.com/43284404/121760557-40962980-cae0-11eb-995b-6343a741a509.png)

After Changes (Microsoft Edge):
![image](https://user-images.githubusercontent.com/43284404/121760568-50ae0900-cae0-11eb-8d08-867ba06dad98.png)


## Further comments

Users who use bigger monitors such as a widescreen tv will see a floating tower unless we tether the tower's bottom to the bottom of the section.
