### PR TITLE
Revised Home Heading Component's Height & Width media queries

### DIFF
--- a/src/pages/Home/styles.scss
+++ b/src/pages/Home/styles.scss
@@ -13,18 +13,16 @@
         background-size: cover;
         overflow: hidden;
 
-        //Changes the height of the heading component
-        @media (max-width: 650px) {
-            height: 700px;
-        }
-        @media (max-width: 550px) {
-            height: 650px;
-        }
-        @media (max-width: 450px) {
+        //If height of heading component is less than 600px, make the height 600px
+        @media (max-height: 600px) {
             height: 600px;
         }
-        @media (max-width: 380px) {
-            height: 540px;
+        //If width is less than 775px and height is less than 800px
+        @media (max-width: 775px) and (max-height: 800px) {
+            height: 700px;
+        }
+        @media (max-width: 450px) and (max-height: 800px) {
+            height: 650px;
         }
 
         // Scrolling clouds in the background of the heading


### PR DESCRIPTION
# Proposed changes

With these changes, resizing the height of the browser under 600px will no longer resize the height of the Home Heading component to be under 600px (covering buttons and titles). Media queries were also added to accommodate the new subscribe button, fix responsiveness, and cut out some blank space at lower width res.

## Types of changes

What types of changes does your code introduce to HackMerced Hub?
_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/HackMerced/HackMerced/blob/master/CONTRIBUTING.md) doc
-   [x] Lint and unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Responsiveness

Check off the different **browsers** and **devices** you have tested on. Note: testing includes Horizontal and Vertical alignments

### Browsers

-   [x] Chrome
-   [ ] Firefox
-   [x] Edge
-   [ ] Safari
-   [ ] Brave
-   [ ] Opera

### Devices

#### Phones

-   [x] Moto G4
-   [x] Galaxy S5
-   [x] Pixel 2
-   [x] Pixel 2 XL
-   [x] iPhone 5/SE
-   [x] iPhone 6/7/8
-   [x] iPhone 6/7/8 Plus
-   [x] iPhone X

#### Tablets

-   [x] iPad
-   [x] iPad Pro

#### Desktops

-   [x] Windows 10
-   [ ] MacOSX
-   [ ] Ubuntu

## Screenshots

Before (Chrome):
![image](https://user-images.githubusercontent.com/43284404/121764304-be196400-caf7-11eb-953e-18d0b3bfa433.png)
After (Chrome):
![image](https://user-images.githubusercontent.com/43284404/121764308-c6719f00-caf7-11eb-9ddc-575e8063083c.png)
Before (Chrome):
![image](https://user-images.githubusercontent.com/43284404/121764353-1486a280-caf8-11eb-8004-a6b0921d926f.png)
After (Chrome):
![image](https://user-images.githubusercontent.com/43284404/121764358-1c464700-caf8-11eb-923e-cda521516e7b.png)


## Further comments

Inspect Element-ing the live site currently and selecting each device shows that the Home Heading component height does not cover the entire height of the phone, which is what I tried to achieve with these media queries (taking the entire height of the screen for both mobile and desktop, without covering any buttons/titles).
