### PR TITLE
Fixed Past-Sponsors-Logos Component code messing with Home Page imgs

### DIFF
--- a/src/pages/Home/styles.scss
+++ b/src/pages/Home/styles.scss
@@ -315,12 +315,10 @@
             height: 850px;
             width: 450px;
             margin: -25% 0% 0% 7%;
-            //margin-left: 7%;
+
             @media (min-height: 800px) {  //Changes the height of the tower
                 height: calc(100vh + 40px);
-                
             }
-
             
             @media (max-width: 775px) {
                 display: none;

--- a/src/pages/SponsorUs/index.tsx
+++ b/src/pages/SponsorUs/index.tsx
@@ -27,7 +27,8 @@ const SponsorUs: FC = (): JSX.Element => {
         <Fragment>
             <Navbar />
             <main className="sponsors-us">
-                {/* Information */}
+                
+                {/* Sponsors Information */}
                 <div className="sponsors-us__content">
                     <div className="sponsors-us__content__heading">
                         Become a sponsor to empower and help <br></br> grow the next generation of HackMerced.
@@ -60,33 +61,26 @@ const SponsorUs: FC = (): JSX.Element => {
                         </p>
                     </section>
                 </div>
+
                 {/* Form to Submit a Request */}
                 <Form formTitle="Sponsor Us" askCompany={true} formRequest="sponsor" />
+
                 {/* Past Sponsors Gallery */}
-                {/* <section className="sponsors-us__past-sponsors">
-                    <h1 className="sponsors-us__past-sponsors__title">Past Sponsors</h1>
-                    <img
-                        src={PAST_SPONSORS}
-                        width="100%"
-                        alt="Past Hackathons Sponsors"
-                        className="sponsors-us__past-sponsors__img"
-                    />
-                </section> */}
-                <div id="past-sponsors">
-                    Our Past Sponsors
-                    <ul className="listt">
-                        <li className="items"><img src={A} alt="ASUCM-Logo" /></li>
-                        <li className="items"><img src={B} alt="MLH-Logo" /></li>
-                        <li className="items"><img src={C} alt="1PASSWORD-Logo" /></li>
-                        <li className="items"><img src={D} alt="HACKMERCED-Logo" /></li>
-                        <li className="items"><img src={E} alt="ADOBE-Logo" /></li>
-                        <li className="items"><img src={F} alt="SKETCH-Logo" /></li>
-                        <li className="items"><img src={G} alt="CITRIS-Logo" /></li>
-                        <li className="items"><img src={H} alt="REPL-Logo" /></li>
-                        <li className="items"><img src={I} alt="ACM-Logo" /></li>
-                        <li className="items"><img src={J} alt="" /></li>
-                        <li className="items"><img src={K} alt="JETBRAINS-Logo" /></li>
-                        <li className="items"><img src={L} alt="SNORKEL-Logo" /></li>
+                <div className="past-sponsors">
+                    <div>Our Past Sponsors</div>
+                    <ul className="list">
+                        <li className="items"><img className="logoimage" src={A} alt="ASUCM-Logo" /></li>
+                        <li className="items"><img className="logoimage" src={B} alt="MLH-Logo" /></li>
+                        <li className="items"><img className="logoimage" src={C} alt="1PASSWORD-Logo" /></li>
+                        <li className="items"><img className="logoimage" src={D} alt="HACKMERCED-Logo" /></li>
+                        <li className="items"><img className="logoimage" src={E} alt="ADOBE-Logo" /></li>
+                        <li className="items"><img className="logoimage" src={F} alt="SKETCH-Logo" /></li>
+                        <li className="items"><img className="logoimage" src={G} alt="CITRIS-Logo" /></li>
+                        <li className="items"><img className="logoimage" src={H} alt="REPL-Logo" /></li>
+                        <li className="items"><img className="logoimage" src={I} alt="ACM-Logo" /></li>
+                        <li className="items"><img className="logoimage" src={J} alt="" /></li>
+                        <li className="items"><img className="logoimage" src={K} alt="JETBRAINS-Logo" /></li>
+                        <li className="items"><img className="logoimage" src={L} alt="SNORKEL-Logo" /></li>
                     </ul>
                 </div>
             </main>

--- a/src/pages/SponsorUs/styles.scss
+++ b/src/pages/SponsorUs/styles.scss
@@ -3,12 +3,14 @@
     justify-content: center;
     padding-bottom: 2%;
     background-color: var(--background);
+
     @media only screen and (max-width: 900px), only screen and (max-height: 640px) {
         margin: 0 auto;
     }
     @media (max-width: 500px) {
         width: 90%;
     }
+
     &__content {
         &__heading {
             font-size: 1.875rem;
@@ -56,85 +58,64 @@
                 line-height: 30px;
             }
         }
+        
         @media only screen and (max-width: 900px),
         only screen and (max-height: 640px) {
             margin: 0;
             padding-top: 2rem;
         }
     }
-    &__past-sponsors {
-        display: block;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        text-align: center;
-        background-color: var(--background);
-        &__title {
-            font-size: 1.875rem;
-            line-height: 1.5em;
-            text-align: center;
-            margin: 2% auto auto auto;
-            font-weight: bold;
-            color: var(--text-color);
-            text-align: center;
-            @media (min-width: 768px) {
-                font-size: 3rem;
-            }
-        }
-    }
 }
 
-img {
-    height: 180px;
-    width: 310px;
-}
 
-#past-sponsors {
+.past-sponsors {
     font-weight: 500;
     font-size: 50px;
     text-align: center;
     color: black;
     margin: 2%;
-}
 
-.listt {
-    padding: 0;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    text-align: center;
-    justify-content: space-evenly;
-    list-style-type: none;
-    margin: 20px 2% 0px 2%;
-}
+    .list {
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        text-align: center;
+        justify-content: space-evenly;
+        list-style-type: none;
+        margin: 20px 2% 0px 2%;
 
-.items {
-    display: flex;
-    border: 2px solid transparent;
-    animation-name: animateIn;
-    animation-duration: 350ms;
-    animation-delay: 300ms;
-    animation-fill-mode: both;
-    animation-timing-function: ease-out-in;
-    padding: 0px;
-    text-align: center;
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-}
+        .items {
+            display: flex;
+            border: 2px solid transparent;
+            animation-name: animateIn;
+            animation-duration: 350ms;
+            animation-delay: 300ms;
+            animation-fill-mode: both;
+            animation-timing-function: ease-out-in;
+            padding: 0px;
+            text-align: center;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 
-@keyframes animateIn {
-    0% {
-        opacity: 0;
-        transform: scale(0.6) translateY(8px) translateY(100px);
-    }
-    100% {
-        opacity: 1;
-    }
-}
-
-@media screen and (max-width: 900px) {
-    img {
-        height: 125px;
-        width: 200px;
+            @keyframes animateIn {
+                0% {
+                    opacity: 0;
+                    transform: scale(0.6) translateY(8px) translateY(100px);
+                }
+                100% {
+                    opacity: 1;
+                }
+            }
+        
+            .logoimage {
+                height: 180px;
+                width: 310px;
+        
+                @media only screen and (max-width: 400px) {
+                    height: 150px;
+                    width: 280px;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
# Proposed changes

Made the Sponsor-Us Page scss and HTML code more readable. Got rid of useless code. Changed 'id' to 'className'. In the scss file, '.img{}' and '#' were messing up the aspect ratio of images on the Home Page, and Sponsor Us Page. The mobile view 'X' button in the hamburger menu was out of view, but it is now visible again.

## Types of changes

What types of changes does your code introduce to HackMerced Hub?
_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/HackMerced/HackMerced/blob/master/CONTRIBUTING.md) doc
-   [x] Lint and unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Responsiveness

Check off the different **browsers** and **devices** you have tested on. Note: testing includes Horizontal and Vertical alignments

### Browsers

-   [x] Chrome
-   [x] Firefox
-   [x] Edge
-   [ ] Safari
-   [ ] Brave
-   [ ] Opera

### Devices

#### Phones

-   [ ] Moto G4
-   [ ] Galaxy S5
-   [ ] Pixel 2
-   [ ] Pixel 2 XL
-   [x] iPhone 5/SE
-   [ ] iPhone 6/7/8
-   [ ] iPhone 6/7/8 Plus
-   [ ] iPhone X

#### Tablets

-   [ ] iPad
-   [ ] iPad Pro

#### Desktops

-   [x] Windows 10
-   [ ] MacOSX
-   [ ] Ubuntu

## Screenshots

Before These Commits (develop branch):
![image](https://user-images.githubusercontent.com/43284404/125210895-633e6e00-e257-11eb-839b-28f82b9137c6.png)
![image](https://user-images.githubusercontent.com/43284404/125210908-72252080-e257-11eb-8c7b-004b5bd87c66.png)
![image](https://user-images.githubusercontent.com/43284404/125210925-8b2dd180-e257-11eb-8439-5dd557e6573b.png)
![image](https://user-images.githubusercontent.com/43284404/125210982-c8925f00-e257-11eb-85f0-4f1db90aa81a.png)

After These Changes:
![image](https://user-images.githubusercontent.com/43284404/125210938-9d0f7480-e257-11eb-8b21-dcc47b0a7990.png)
![image](https://user-images.githubusercontent.com/43284404/125210942-a26cbf00-e257-11eb-9e24-655b494e79a3.png)
![image](https://user-images.githubusercontent.com/43284404/125210953-af89ae00-e257-11eb-8b55-a82837220e36.png)
![image](https://user-images.githubusercontent.com/43284404/125210962-b9abac80-e257-11eb-9222-ff87aaef5ab3.png)


## Further comments

Shakti's changes, Sponsors Page's Our-Past-Sponsors Component had code that were messing up aspect ratios of images ('HackMerced' Title img and 'About Us' Section's img) on the Home Page. Code also moved the location of mobile view's hamburger menu 'X' button.
