### PR TITLE
Fixed Home Heading component height not taking full vh of phones

### DIFF
--- a/src/pages/Home/styles.scss
+++ b/src/pages/Home/styles.scss
@@ -15,9 +15,9 @@
         @media only screen and (max-width: 910px) {
             height: calc(100vh - 55px);
         }
-        //If height of heading component is less than 650px, make the height 650px
-        @media only screen and (max-height: 650px) {
-            height: 650px;
+        //If height of heading component is less than 550px, make the height 495px
+        @media only screen and (max-height: 550px) {
+            height: 495px;
         }
 
         // Scrolling clouds in the background of the heading
@@ -159,11 +159,11 @@
                 }
 
                 &__image {
-                    height: calc(100vh + 70px);
+                    height: calc(100vh + 80px);
                     width: calc(28vw);
 
-                    @media only screen and (max-height: 650px) {
-                        height: 720px;
+                    @media only screen and (max-height: 550px) {
+                        height: 631px;
                     }
                 }
             }
@@ -174,6 +174,7 @@
                 text-align: center;
 
                 @media only screen and (max-width: 910px) {
+                    padding-top: 2%;
                     padding-bottom: 20%;
                 }
 


### PR DESCRIPTION
# Proposed changes

Fixed home heading component's height media query so that the component's height is the full viewheight of the user's device. Tested for all phones on Chrome Inspect Element and Microsoft Edge. I also added a tiny padding-top: 2% to the Title component when the tower disappears (width under 910px), so that the entire component is never touching the bottom of the navbar.

## Types of changes

What types of changes does your code introduce to HackMerced Hub?
_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/HackMerced/HackMerced/blob/master/CONTRIBUTING.md) doc
-   [x] Lint and unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Responsiveness

Check off the different **browsers** and **devices** you have tested on. Note: testing includes Horizontal and Vertical alignments

### Browsers

-   [x] Chrome
-   [ ] Firefox
-   [x] Edge
-   [ ] Safari
-   [ ] Brave
-   [ ] Opera

### Devices

#### Phones

-   [x] Moto G4
-   [x] Galaxy S5
-   [x] Pixel 2
-   [x] Pixel 2 XL
-   [x] iPhone 5/SE
-   [x] iPhone 6/7/8
-   [x] iPhone 6/7/8 Plus
-   [x] iPhone X

#### Tablets

-   [x] iPad
-   [x] iPad Pro

#### Desktops

-   [x] Windows 10
-   [ ] MacOSX
-   [ ] Ubuntu

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/43284404/134441736-d787fc7b-a290-4299-b0b2-a6d6fedaf0d4.png)
After (scrolled down a tiiiny bit and you can already see the height is perfectly the same as the device's viewport):
![image](https://user-images.githubusercontent.com/43284404/134441768-c6904d7b-2fb1-47a0-b2aa-b399196e8636.png)


## Further comments

I did not make 1-2 media queries for the hackmerced tower for when it gets too stretched and blurry because they'd require specific bounds, which isn't really worth it as not that many people will have those big resolution monitors.
