### PR TITLE
Made mouse trail look like fruit ninja slice effect. Fixed navbar flex

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -40,7 +40,8 @@ a {
 }
 
 ::-webkit-scrollbar {
-    width: 10px;
+    height: 0px;  // Height of horizontal scrollbar
+    width: 10px;  // Width of vertical scrollbar
 }
 
 ::-webkit-scrollbar-track {
@@ -54,8 +55,8 @@ a {
 
 .trail { /* className for the trail elements (utils/mousetrail.js) */
     position: absolute;
-    height: 6px; width: 6px;
-    border-radius: 3px;
+    height: 10px; width: 10px;
+    border-radius: 6px;
     background: rgb(255, 123, 0);
     pointer-events:none; //Allows user to click through the mouse trail: https://stackoverflow.com/questions/64930959/how-to-make-a-mouse-trail-with-css-js-so-that-elements-are-still-clickable
 }

--- a/src/utils/mousetrail.js
+++ b/src/utils/mousetrail.js
@@ -23,12 +23,12 @@ var Dot = function () {
 // The Dot.prototype.draw() method sets the position of
 // the object's <div> node
 Dot.prototype.draw = function () {
-    this.node.style.left = this.x + "px";
-    this.node.style.top = this.y + "px";
+    this.node.style.left = (this.x - 6.3) + "px";
+    this.node.style.top = (this.y - 5) + "px";
 };
 
 // Creates the Dot objects, populates the dots array
-for (var i = 0; i < 10; i++) {
+for (var i = 0; i < 20; i++) {
     var d = new Dot();
     dots.push(d);
 }
@@ -47,8 +47,8 @@ function draw() {
         dot.x = x;
         dot.y = y;
         dot.draw();
-        x += (nextDot.x - dot.x) * 0.6;
-        y += (nextDot.y - dot.y) * 0.6;
+        x += (nextDot.x - dot.x) * 0.1;
+        y += (nextDot.y - dot.y) * 0.1;
     });
 }
 


### PR DESCRIPTION
# Proposed changes

Fixed horizontal navbar appearing and enlarging the width of the browser by a tiny bit, every time the mouse trail was near the bottom right edge of the browser.

## Types of changes

What types of changes does your code introduce to HackMerced Hub?
_Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/HackMerced/HackMerced/blob/master/CONTRIBUTING.md) doc
-   [x] Lint and unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## Responsiveness

Check off the different **browsers** and **devices** you have tested on. Note: testing includes Horizontal and Vertical alignments

### Browsers

-   [x] Chrome
-   [ ] Firefox
-   [x] Edge
-   [ ] Safari
-   [ ] Brave
-   [ ] Opera

### Devices

#### Phones

-   [ ] Moto G4
-   [ ] Galaxy S5
-   [ ] Pixel 2
-   [ ] Pixel 2 XL
-   [ ] iPhone 5/SE
-   [ ] iPhone 6/7/8
-   [ ] iPhone 6/7/8 Plus
-   [ ] iPhone X

#### Tablets

-   [ ] iPad
-   [ ] iPad Pro

#### Desktops

-   [x] Windows 10
-   [ ] MacOSX
-   [ ] Ubuntu

## Screenshots

![image](https://user-images.githubusercontent.com/43284404/146285965-15fef0de-c514-47e5-bbe4-c6784789f5a4.png)
![image](https://user-images.githubusercontent.com/43284404/146286352-c66d68fb-9a93-474c-81ba-3c544ca1df66.png)


## Further comments

It looks kinda weird to have both the mouse trail and default mouse cursor. Maybe make the default mouse cursor invisible?

We definitely need a media query to {display: none} the mousetrail when resolution width is under lowest computer size.
